### PR TITLE
add textProps-option

### DIFF
--- a/lib/ToastContainer.js
+++ b/lib/ToastContainer.js
@@ -86,7 +86,8 @@ class ToastContainer extends Component {
         onHide: PropTypes.func,
         onHidden: PropTypes.func,
         onShow: PropTypes.func,
-        onShown: PropTypes.func
+        onShown: PropTypes.func,
+        textProps: PropTypes.object
     };
 
     static defaultProps = {
@@ -219,11 +220,14 @@ class ToastContainer extends Component {
                     pointerEvents="none"
                     ref={ele => this._root = ele}
                 >
-                    <Text style={[
-                        styles.textStyle,
-                        props.textStyle,
-                        props.textColor && {color: props.textColor}
-                    ]}>
+                    <Text
+                        {...props.textProps}
+                        style={[
+                            styles.textStyle,
+                            props.textStyle,
+                            props.textColor && {color: props.textColor}
+                        ]}
+                    >
                         {this.props.children}
                     </Text>
                 </Animated.View>


### PR DESCRIPTION
Add a `textProps`-option, to be able to send props to the text element.
Needed to for instance set `allowFontScaling` to `false`.