### PR TITLE
Fix infinite render() when Toast.show() in componentDidMount()

### DIFF
--- a/lib/Toast.js
+++ b/lib/Toast.js
@@ -14,12 +14,15 @@ class Toast extends Component {
     static durations = durations;
 
     static show = (message, options = {position: positions.BOTTOM, duration: durations.SHORT}) => {
-        return new RootSiblings(<ToastContainer
-            {...options}
-            visible={true}
-        >
-            {message}
-        </ToastContainer>);
+        return new Promise(resolve => {
+            setTimeout(() => resolve(new RootSiblings(<ToastContainer
+                    {...options}
+                    visible={true}
+                >
+                    {message}
+                </ToastContainer>),
+            ), 0);
+        });
     };
 
     static hide = toast => {


### PR DESCRIPTION
This is BREAKING change because Toast.show() returns Promise<>.
Please check this commit is best way.

I tried to show Toast in componentDidMount() but appending sibling makes infinite render() call.
To escape this situation, I tried to show Toast in another context and it worked.
Please check this.