### PR TITLE
Fixed duration set to zero bug

### DIFF
--- a/lib/ToastContainer.js
+++ b/lib/ToastContainer.js
@@ -140,7 +140,7 @@ class ToastContainer extends Component {
     componentWillUnmount = () => {
         Dimensions.removeEventListener('change', this._windowChanged);
         Keyboard.removeListener('keyboardDidChangeFrame', this._keyboardDidChangeFrame);
-        this._hide();
+        this._root && this._hide();
     };
 
     _animating = false;


### PR DESCRIPTION
Your component wrapper, for some reason, sets the duration to zero, so that the "duration" props are ignored. I removed them and now the Toast automatically hides after the specified duration.