### PR TITLE
Export ToastContainer to use independently from Toast and RootSibling

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,6 @@ declare module "react-native-root-toast"{
         static durations:Durations;
         static positions:Positions;
     }
+
+    export class ToastContainer extends React.Component<ToastProps> {}
 }
-
-

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
 import Toast from './lib/Toast';
+import ToastContainer from './lib/ToastContainer';
+
 export * from './lib/Toast';
+export { ToastContainer };
 export default Toast;


### PR DESCRIPTION
You might use ToastContainer component without RootSiblings mechanism (i.e. not create implicitly node with ToastContainer for your app root or roots). 
For example, RootSiblings doubles toast messages for both sidemenu and plain screens (react-native-navigation v2)

![screenshot_1539859310_1](https://user-images.githubusercontent.com/5960152/47270732-ad97d200-d578-11e8-9d80-a70bb4a1c28b.png)
