### PR TITLE
Adding support for rendering React component

### DIFF
--- a/lib/ToastContainer.js
+++ b/lib/ToastContainer.js
@@ -227,6 +227,24 @@ class ToastContainer extends Component {
             bottom: keyboardHeight
         };
 
+        let toastChildContent
+        // if the passed content is string then use Text to render
+        // other wise use view
+        if(typeof this.props.children === 'string'){
+            toastChildContent = <Text style={[
+                styles.textStyle,
+                props.textStyle,
+                props.textColor && {color: props.textColor}
+            ]}>
+                {this.props.children}
+            </Text>
+        }else{
+            // passed component can have their own style.
+            toastChildContent =  <View>
+            {this.props.children}
+        </View>
+        }
+
         return (this.state.visible || this._animating) ? <View
             style={[
                 styles.defaultStyle,
@@ -255,13 +273,7 @@ class ToastContainer extends Component {
                     pointerEvents="none"
                     ref={ele => this._root = ele}
                 >
-                    <Text style={[
-                        styles.textStyle,
-                        props.textStyle,
-                        props.textColor && {color: props.textColor}
-                    ]}>
-                        {this.props.children}
-                    </Text>
+                    {toastChildContent}
                 </Animated.View>
             </TouchableWithoutFeedback>
         </View> : null;


### PR DESCRIPTION
Current ToastContainer.js class can only render Text elements We can use View as a container if the child is not a text to render react component.