### PR TITLE
switch to deprecated-react-native-prop-types

### DIFF
--- a/lib/ToastContainer.js
+++ b/lib/ToastContainer.js
@@ -3,7 +3,6 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import {
-    ViewPropTypes,
     StyleSheet,
     View,
     Text,
@@ -13,6 +12,7 @@ import {
     Easing,
     Keyboard
 } from 'react-native';
+import { ViewPropTypes, TextPropTypes } from 'deprecated-react-native-prop-types';
 const TOAST_MAX_WIDTH = 0.8;
 const TOAST_ANIMATION_DURATION = 200;
 
@@ -74,7 +74,7 @@ class ToastContainer extends Component {
         opacity: PropTypes.number,
         shadowColor: PropTypes.string,
         textColor: PropTypes.string,
-        textStyle: Text.propTypes.style,
+        textStyle: TextPropTypes.style,
         delay: PropTypes.number,
         hideOnPress: PropTypes.bool,
         onPress: PropTypes.func,
@@ -194,11 +194,11 @@ class ToastContainer extends Component {
                     pointerEvents: 'none'
                 });
             }
-            
+
             if (this.props.onHide) {
                 this.props.onHide(this.props.siblingManager);
             }
-            
+
             Animated.timing(this.state.opacity, {
                 toValue: 0,
                 duration: this.props.animation ? TOAST_ANIMATION_DURATION : 0,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "focus"
     ],
     "dependencies": {
+        "deprecated-react-native-prop-types": "^2.3.0",
         "prop-types": "^15.5.10",
         "react-native-root-siblings": "^4.0.0"
     },


### PR DESCRIPTION
switch to `deprecated-react-native-prop-types`

Refs:
https://github.com/magicismight/react-native-root-toast/issues/134
https://github.com/magicismight/react-native-root-toast/issues/25
https://github.com/magicismight/react-native-root-toast/issues/155

