### PR TITLE
fixing onPress event + adding children option other than string

### DIFF
--- a/lib/ToastContainer.js
+++ b/lib/ToastContainer.js
@@ -240,6 +240,7 @@ class ToastContainer extends Component {
                   this.props.hideOnPress ? this._hide() : null
                 }}
             >
+              <View>
                 <Animated.View
                     style={[
                         styles.containerStyle,
@@ -255,14 +256,19 @@ class ToastContainer extends Component {
                     pointerEvents="none"
                     ref={ele => this._root = ele}
                 >
-                    <Text style={[
-                        styles.textStyle,
-                        props.textStyle,
-                        props.textColor && {color: props.textColor}
-                    ]}>
-                        {this.props.children}
-                    </Text>
+                  {typeof this.props.children === 'string' ? (
+                      <Text style={[
+                          styles.textStyle,
+                          props.textStyle,
+                          props.textColor && {color: props.textColor}
+                      ]}>
+                          {this.props.children}
+                      </Text>
+                    ) : (
++                        this.props.children
++                   )}
                 </Animated.View>
+              </View>
             </TouchableWithoutFeedback>
         </View> : null;
     }


### PR DESCRIPTION
- Fixed onPress event that wasn't working, it wasn't firing (Web). Issue is TouchableWithoutFeedback always needs to have child View component. So a component that composes a View isn't enough. So added an extra View around Animated.View
- Added an option to pass either a string as children prop where we applied textStyle and textColor like before or any type of children

I tested those modifications in my project with patch-package and it's working great and shouldn't break anything with anyone who has that library installed