### PR TITLE
fix: passing accessible=false to Wrapper

### DIFF
--- a/lib/ToastContainer.js
+++ b/lib/ToastContainer.js
@@ -228,7 +228,7 @@ class ToastContainer extends Component {
       <Wrapper
         style={[styles.defaultStyle, position]}
         pointerEvents="box-none"
-        accessible={props.accessible ? props.accessible : true}
+        accessible={props.accessible != null ? props.accessible : true}
         accessibilityLabel={
           this.props.accessibilityLabel
             ? this.props.accessibilityLabel


### PR DESCRIPTION
In the current codebase, an `accessible=false` prop won't be passed on to `Wrapper`, because of the line

```
accessible={props.accessible ? props.accessible : true}
```

This will always set `Wrapper.accessible` to true.

This PR changes this such that `accessible=false` will be passed on.

Background: the current implementation does not seem to be testable under maestro.dev - there are other RN components that have the same problem, see for example [here](https://github.com/mobile-dev-inc/Maestro/issues/1493). One of the possible solutions is to set `accessible=false` on the container of the overlay / toast.